### PR TITLE
Ssis2016-2012 pipeline bug fix

### DIFF
--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Destination.OleDb.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Destination.OleDb.fs
@@ -14,7 +14,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{4ADA7EAA-136C-4215-8098-D7A7C27FC0D1}"
+let classId = "DTSAdapter.OLEDBDestination.3"
 
 module FastLoadOptionParser =
     open FParsec

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Destination.Recordset.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Destination.Recordset.fs
@@ -13,7 +13,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{C457FD7E-CE98-4C4B-AEFE-F3AE0044F181}"
+let classId = "DTSAdapter.RecordsetDestination.3"
 
 let (|ReadOnly|ReadWrite|) (value:string) =
     match value.ToUpperInvariant() with

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Source.FlatFile.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Source.FlatFile.fs
@@ -8,7 +8,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{D23FD76B-F51D-420F-BBCB-19CBF6AC1AB4}"
+let classId = "DTSAdapter.FlatFileSource.3"
 
 let readMetaDataColumn nav =
     let refId = nav |> Extractions.anyString "@refId" ""

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Source.OleDb.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Source.OleDb.fs
@@ -10,7 +10,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{165A526D-D5DE-47FF-96A6-F8274C19826B}"
+let classId = "DTSAdapter.OLEDBSource.3"
 
 let readMetaDataColumn nav =
     let refId = nav |> Extractions.anyString "@refId" ""

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Aggregate.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Aggregate.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{5B201335-B360-485C-BB93-75C34E09B3D3}"
+let classId = "DTSTransform.Aggregate.3"
 
 let mapScale =
     function

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.ConditionalSplit.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.ConditionalSplit.fs
@@ -10,7 +10,7 @@ open Chimayo.Ssis.Reader2012.Pipeline
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{7F88F654-4E20-4D14-84F4-AF9C925D3087}"
+let classId = "DTSTransform.ConditionalSplit.3"
 
 let readOutput nav =
     {

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.DataConversion.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.DataConversion.fs
@@ -12,7 +12,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{62B1106C-7DB8-4EC8-ADD6-4C664DFFC54A}"
+let classId = "DTSTransform.DataConvert.3"
 
 let readColumn nav : DfDataConversionColumn =
     let name = nav |> Extractions.anyString "@name" ""

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.DerivedColumn.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.DerivedColumn.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2012.Pipeline
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{49928E82-9C4E-49F0-AABE-3812B82707EC}"
+let classId = "DTSTransform.DerivedColumn.3"
 
 let readNewColumn nav : DfDerivedColumnColumn =
     let codepage = nav |> Extractions.anyInt "@codePage" Defaults.codePage

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Lookup.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Lookup.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2012.Common
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{671046B0-AA63-4C9F-90E4-C06E0B710CE3}"
+let classId = "DTSTransform.Lookup.3"
 
 let readOutputColumns nav =
     let codepage = nav |> Extractions.anyInt "@codePage" Defaults.codePage

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Multicast.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.Multicast.fs
@@ -4,6 +4,6 @@ open Chimayo.Ssis.Xml.XPath
 open Chimayo.Ssis.Ast.DataFlow
 
 [<Literal>]
-let classId = "{EC139FBC-694E-490B-8EA7-35690FB0F445}"
+let classId = "DTSTransform.Multicast.3"
 
 let read (nav:NavigatorRec) = DfMulticast

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.RowCount.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.RowCount.fs
@@ -11,7 +11,7 @@ open Chimayo.Ssis.Reader2012.Pipeline
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{E2697D8C-70DA-42B2-8208-A19CE3A9FE41}"
+let classId = "DTSTransform.RowCount.3"
 
 let readResultVariable nav =
     nav 

--- a/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.UnionAll.fs
+++ b/src/Chimayo.Ssis.Reader2012/Pipeline.Transform.UnionAll.fs
@@ -11,7 +11,7 @@ open Chimayo.Ssis.Reader2012.Pipeline
 open Chimayo.Ssis.Reader2012.Pipeline.Common
 
 [<Literal>]
-let classId = "{B594E9A8-4351-4939-891C-CFE1AB93E925}"
+let classId = "DTSTransform.UnionAll.3"
 
 let readInputColumn nav =
     let inputName = nav |> Extractions.anyString "ancestor::input/@name" "" |> DfName

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Destination.OleDb.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Destination.OleDb.fs
@@ -14,7 +14,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{4ADA7EAA-136C-4215-8098-D7A7C27FC0D1}"
+let classId = "Microsoft.OLEDBDestination"
 
 module FastLoadOptionParser =
     open FParsec

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Destination.Recordset.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Destination.Recordset.fs
@@ -13,7 +13,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{C457FD7E-CE98-4C4B-AEFE-F3AE0044F181}"
+let classId = "Microsoft.RecordsetDestination"
 
 let (|ReadOnly|ReadWrite|) (value:string) =
     match value.ToUpperInvariant() with

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Source.FlatFile.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Source.FlatFile.fs
@@ -8,7 +8,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{D23FD76B-F51D-420F-BBCB-19CBF6AC1AB4}"
+let classId = "Microsoft.FlatFileSource"
 
 let readMetaDataColumn nav =
     let refId = nav |> Extractions.anyString "@refId" ""

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Source.OleDb.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Source.OleDb.fs
@@ -10,7 +10,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{165A526D-D5DE-47FF-96A6-F8274C19826B}"
+let classId = "Microsoft.OLEDBSource"
 
 let readMetaDataColumn nav =
     let refId = nav |> Extractions.anyString "@refId" ""

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Aggregate.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Aggregate.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{5B201335-B360-485C-BB93-75C34E09B3D3}"
+let classId = "Microsoft.Aggregate"
 
 let mapScale =
     function

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.ConditionalSplit.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.ConditionalSplit.fs
@@ -10,7 +10,7 @@ open Chimayo.Ssis.Reader2016.Pipeline
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{7F88F654-4E20-4D14-84F4-AF9C925D3087}"
+let classId = "Microsoft.ConditionalSplit"
 
 let readOutput nav =
     {

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.DataConversion.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.DataConversion.fs
@@ -12,7 +12,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{62B1106C-7DB8-4EC8-ADD6-4C664DFFC54A}"
+let classId = "Microsoft.DataConvert"
 
 let readColumn nav : DfDataConversionColumn =
     let name = nav |> Extractions.anyString "@name" ""

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.DerivedColumn.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.DerivedColumn.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2016.Pipeline
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{49928E82-9C4E-49F0-AABE-3812B82707EC}"
+let classId = "Microsoft.DerivedColumn"
 
 let readNewColumn nav : DfDerivedColumnColumn =
     let codepage = nav |> Extractions.anyInt "@codePage" Defaults.codePage

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Lookup.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Lookup.fs
@@ -9,7 +9,7 @@ open Chimayo.Ssis.Reader2016.Common
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{671046B0-AA63-4C9F-90E4-C06E0B710CE3}"
+let classId = "Microsoft.Lookup"
 
 let readOutputColumns nav =
     let codepage = nav |> Extractions.anyInt "@codePage" Defaults.codePage

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Multicast.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.Multicast.fs
@@ -4,6 +4,6 @@ open Chimayo.Ssis.Xml.XPath
 open Chimayo.Ssis.Ast.DataFlow
 
 [<Literal>]
-let classId = "{EC139FBC-694E-490B-8EA7-35690FB0F445}"
+let classId = "Microsoft.Multicast"
 
 let read (nav:NavigatorRec) = DfMulticast

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.RowCount.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.RowCount.fs
@@ -11,7 +11,7 @@ open Chimayo.Ssis.Reader2016.Pipeline
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{E2697D8C-70DA-42B2-8208-A19CE3A9FE41}"
+let classId = "Microsoft.RowCount"
 
 let readResultVariable nav =
     nav 

--- a/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.UnionAll.fs
+++ b/src/Chimayo.Ssis.Reader2016/Pipeline.Transform.UnionAll.fs
@@ -11,7 +11,7 @@ open Chimayo.Ssis.Reader2016.Pipeline
 open Chimayo.Ssis.Reader2016.Pipeline.Common
 
 [<Literal>]
-let classId = "{B594E9A8-4351-4939-891C-CFE1AB93E925}"
+let classId = "Microsoft.UnionAll"
 
 let readInputColumn nav =
     let inputName = nav |> Extractions.anyString "ancestor::input/@name" "" |> DfName


### PR DESCRIPTION
Updated Reader2012 and Reader2016 to use names for ComponentClassId instead of GUIDs.  